### PR TITLE
Remove <REST-LISTEN-PORT> from arguments usage output

### DIFF
--- a/scripts/create_and_sign_stake_pool_certificate.sh
+++ b/scripts/create_and_sign_stake_pool_certificate.sh
@@ -6,7 +6,7 @@ COLORS=1
 ADDRTYPE="--testing"
 
 if [ $# -ne 1 ]; then
-    echo "usage: $0 <REST-LISTEN-PORT> <ACCOUNT_SK>"
+    echo "usage: $0 <ACCOUNT_SK>"
     echo "    <SOURCE-SK>   The Secret key of the Source address"
     exit 1
 fi


### PR DESCRIPTION
<REST-LISTEN-PORT> is unused in script. If <REST-LISTEN-PORT> is entered, then ACCOUNT_SK="$1" throws error.